### PR TITLE
Prefixed Zephyr public headers with <zephyr/..> using scripts/utils/migrate_includes.py from the Zephyr repository

### DIFF
--- a/include/zpp/atomic_bitset.hpp
+++ b/include/zpp/atomic_bitset.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_ATOMIC_BITSET_HPP
 #define ZPP_INCLUDE_ZPP_ATOMIC_BITSET_HPP
 
-#include <sys/atomic.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/__assert.h>
 
 #include <cstddef>
 

--- a/include/zpp/atomic_var.hpp
+++ b/include/zpp/atomic_var.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_ATOMIC_VAR_HPP
 #define ZPP_INCLUDE_ZPP_ATOMIC_VAR_HPP
 
-#include <sys/atomic.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/__assert.h>
 
 #include <cstddef>
 

--- a/include/zpp/clock.hpp
+++ b/include/zpp/clock.hpp
@@ -7,9 +7,9 @@
 #ifndef ZPP_INCLUDE_ZPP_CLOCK_HPP
 #define ZPP_INCLUDE_ZPP_CLOCK_HPP
 
-#include <kernel.h>
-#include <sys_clock.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <limits>

--- a/include/zpp/condition_variable.hpp
+++ b/include/zpp/condition_variable.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_CONDITION_VARIABLE_HPP
 #define ZPP_INCLUDE_ZPP_CONDITION_VARIABLE_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 

--- a/include/zpp/error_code.hpp
+++ b/include/zpp/error_code.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_ERROR_CODE_HPP
 #define ZPP_INCLUDE_ZPP_ERROR_CODE_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 #include <errno.h>
 
 namespace zpp {

--- a/include/zpp/fifo.hpp
+++ b/include/zpp/fifo.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_FIFO_HPP
 #define ZPP_INCLUDE_ZPP_FIFO_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <limits>

--- a/include/zpp/fmt.hpp
+++ b/include/zpp/fmt.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_FMT_HPP
 #define ZPP_INCLUDE_ZPP_FMT_HPP
 
-#include <zephyr.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <cstddef>
 #include <chrono>

--- a/include/zpp/futex.hpp
+++ b/include/zpp/futex.hpp
@@ -9,8 +9,8 @@
 
 #ifdef CONFIG_USERSPACE
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 

--- a/include/zpp/heap.hpp
+++ b/include/zpp/heap.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_HEAP_HPP
 #define ZPP_INCLUDE_ZPP_HEAP_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <array>

--- a/include/zpp/lock_guard.hpp
+++ b/include/zpp/lock_guard.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_LOCK_GUARD_HPP
 #define ZPP_INCLUDE_ZPP_LOCK_GUARD_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 

--- a/include/zpp/mem_slab.hpp
+++ b/include/zpp/mem_slab.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_MEM_SLAB_HPP
 #define ZPP_INCLUDE_ZPP_MEM_SLAB_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <cstdint>
 #include <chrono>

--- a/include/zpp/mutex.hpp
+++ b/include/zpp/mutex.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_MUTEX_HPP
 #define ZPP_INCLUDE_ZPP_MUTEX_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 

--- a/include/zpp/poll_event.hpp
+++ b/include/zpp/poll_event.hpp
@@ -9,8 +9,8 @@
 
 #ifdef CONFIG_POLL
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <limits>

--- a/include/zpp/poll_event_set.hpp
+++ b/include/zpp/poll_event_set.hpp
@@ -9,8 +9,8 @@
 
 #ifdef CONFIG_POLL
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <limits>

--- a/include/zpp/poll_signal.hpp
+++ b/include/zpp/poll_signal.hpp
@@ -9,8 +9,8 @@
 
 #ifdef CONFIG_POLL
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <limits>
 #include <optional>

--- a/include/zpp/result.hpp
+++ b/include/zpp/result.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_RESULT_HPP
 #define ZPP_INCLUDE_ZPP_RESULT_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <zpp/error_code.hpp>
 

--- a/include/zpp/sched.hpp
+++ b/include/zpp/sched.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_SCHED_HPP
 #define ZPP_INCLUDE_ZPP_SCHED_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 namespace zpp {
 

--- a/include/zpp/sem.hpp
+++ b/include/zpp/sem.hpp
@@ -9,8 +9,8 @@
 
 #include <zpp/thread.hpp>
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <limits>

--- a/include/zpp/sys_mutex.hpp
+++ b/include/zpp/sys_mutex.hpp
@@ -9,8 +9,8 @@
 
 #ifdef CONFIG_USERSPACE
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 

--- a/include/zpp/thread.hpp
+++ b/include/zpp/thread.hpp
@@ -17,9 +17,9 @@
 #include <zpp/error_code.hpp>
 #include <zpp/heap.hpp>
 
-#include <kernel.h>
-#include <sys/__assert.h>
-#include <sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
 
 #include <functional>
 #include <chrono>

--- a/include/zpp/thread_attr.hpp
+++ b/include/zpp/thread_attr.hpp
@@ -9,8 +9,8 @@
 
 #include <zpp/thread_prio.hpp>
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <utility>

--- a/include/zpp/thread_data.hpp
+++ b/include/zpp/thread_data.hpp
@@ -7,9 +7,9 @@
 #ifndef ZPP_INCLUDE_ZPP_THREAD_DATA_HPP
 #define ZPP_INCLUDE_ZPP_THREAD_DATA_HPP
 
-#include <kernel.h>
-#include <sys/arch_interface.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/arch_interface.h>
+#include <zephyr/sys/__assert.h>
 
 namespace zpp {
 

--- a/include/zpp/thread_id.hpp
+++ b/include/zpp/thread_id.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_THREAD_ID_HPP
 #define ZPP_INCLUDE_ZPP_THREAD_ID_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 namespace zpp {
 

--- a/include/zpp/thread_prio.hpp
+++ b/include/zpp/thread_prio.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_THREAD_PRIO_HPP
 #define ZPP_INCLUDE_ZPP_THREAD_PRIO_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 namespace zpp {
 

--- a/include/zpp/thread_stack.hpp
+++ b/include/zpp/thread_stack.hpp
@@ -7,9 +7,9 @@
 #ifndef ZPP_INCLUDE_ZPP_THREAD_STACK_HPP
 #define ZPP_INCLUDE_ZPP_THREAD_STACK_HPP
 
-#include <kernel.h>
-#include <sys/arch_interface.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/arch_interface.h>
+#include <zephyr/sys/__assert.h>
 
 namespace zpp {
 

--- a/include/zpp/timer.hpp
+++ b/include/zpp/timer.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_TIMER_HPP
 #define ZPP_INCLUDE_ZPP_TIMER_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 #include <functional>

--- a/include/zpp/unique_lock.hpp
+++ b/include/zpp/unique_lock.hpp
@@ -7,8 +7,8 @@
 #ifndef ZPP_INCLUDE_ZPP_UNIQUE_LOCK_HPP
 #define ZPP_INCLUDE_ZPP_UNIQUE_LOCK_HPP
 
-#include <kernel.h>
-#include <sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
 
 #include <chrono>
 

--- a/samples/kernel/condition_variables/condvar/src/main.cpp
+++ b/samples/kernel/condition_variables/condvar/src/main.cpp
@@ -5,9 +5,9 @@
 /// SPDX-License-Identifier: Apache-2.0
 ///
 
-#include <zephyr.h>
-#include <arch/cpu.h>
-#include <sys/arch_interface.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/arch_interface.h>
 
 #include <zpp.hpp>
 #include <chrono>

--- a/samples/kernel/condition_variables/simple/src/main.cpp
+++ b/samples/kernel/condition_variables/simple/src/main.cpp
@@ -4,9 +4,9 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-#include <zephyr.h>
-#include <arch/cpu.h>
-#include <sys/arch_interface.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/arch_interface.h>
 
 #include <zpp.hpp>
 #include <chrono>

--- a/tests/condition_variable/src/main.cpp
+++ b/tests/condition_variable/src/main.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <ztest.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #include<string.h>
 

--- a/tests/result/src/main.cpp
+++ b/tests/result/src/main.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <ztest.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #include <zephyr/kernel.h>
 


### PR DESCRIPTION
Added 'hpp' postfix to extension list in migrate_include.py see https://github.com/zephyrproject-rtos/zephyr/pull/53042 
and https://github.com/zephyrproject-rtos/zephyr/releases/tag/zephyr-v3.1.0 for details

it seems that include/zpp/error_code.hpp have had line ending changes done by the migrate_include.py script