### PR TITLE
Zephyr 3.7 update

### DIFF
--- a/include/zpp/fmt.hpp
+++ b/include/zpp/fmt.hpp
@@ -10,138 +10,129 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 
-#include <cstddef>
 #include <chrono>
+#include <cstddef>
 #include <utility>
 
 namespace zpp {
 
 namespace internal {
 
-inline void print_arg() noexcept { }
-inline void print_arg(bool v) noexcept { printk("%d", (int)v); }
-inline void print_arg(float v) noexcept { printk("%f", v); }
+inline void print_arg() noexcept {}
+inline void print_arg(bool v) noexcept { printk("%d", static_cast<int>(v)); }
+inline void print_arg(float v) noexcept { printk("%f", static_cast<double>(v)); }
 inline void print_arg(double v) noexcept { printk("%g", v); }
 inline void print_arg(char v) noexcept { printk("%c", v); }
 inline void print_arg(const char* v) noexcept { printk("%s", v); }
 inline void print_arg(const void* v) noexcept { printk("%p", v); }
-inline void print_arg(uint8_t v) noexcept { printk("%d", (uint32_t)v); }
-inline void print_arg(int8_t v) noexcept { printk("%d", (int32_t)v); }
-inline void print_arg(uint16_t v) noexcept { printk("%d", (uint32_t)v); }
-inline void print_arg(int16_t v) noexcept { printk("%d", (int32_t)v); }
+inline void print_arg(uint8_t v) noexcept { printk("%d", static_cast<uint32_t>(v)); }
+inline void print_arg(int8_t v) noexcept { printk("%d", static_cast<int32_t>(v)); }
+inline void print_arg(uint16_t v) noexcept { printk("%d", static_cast<uint32_t>(v)); }
+inline void print_arg(int16_t v) noexcept { printk("%d", static_cast<int32_t>(v)); }
 inline void print_arg(uint32_t v) noexcept { printk("%d", v); }
 inline void print_arg(int32_t v) noexcept { printk("%d", v); }
 inline void print_arg(uint64_t v) noexcept { printk("%lld", v); }
 inline void print_arg(int64_t v) noexcept { printk("%lld", v); }
 
-template<class T_Rep, class T_Period>
-inline void print_arg(std::chrono::duration<T_Rep, T_Period> v)
-{
-  using namespace std::chrono;
+template <class T_Rep, class T_Period>
+inline void print_arg(std::chrono::duration<T_Rep, T_Period> v) {
+    using namespace std::chrono;
 
-  auto s = duration_cast<seconds>(v);
-  v -= duration_cast<decltype(v)>(s);
-  auto ms = duration_cast<milliseconds>(v);
-  v -= duration_cast<decltype(v)>(ms);
-  auto us = duration_cast<microseconds>(v);
-  v -= duration_cast<decltype(v)>(us);
-  auto ns = duration_cast<nanoseconds>(v);
+    auto s = duration_cast<seconds>(v);
+    v -= duration_cast<decltype(v)>(s);
+    auto ms = duration_cast<milliseconds>(v);
+    v -= duration_cast<decltype(v)>(ms);
+    auto us = duration_cast<microseconds>(v);
+    v -= duration_cast<decltype(v)>(us);
+    auto ns = duration_cast<nanoseconds>(v);
 
-  printk("%d.%03d%03d%03ds",
-    (int)s.count(), (int)ms.count(),
-    (int)us.count(), (int)ns.count());
+    printk("%d.%03d%03d%03ds", (int)s.count(), (int)ms.count(), (int)us.count(), (int)ns.count());
 }
 
-template<class T_Clock>
-inline void print_arg(std::chrono::time_point<T_Clock> v)
-{
-  print_arg(v.time_since_epoch());
+template <class T_Clock>
+inline void print_arg(std::chrono::time_point<T_Clock> v) {
+    print_arg(v.time_since_epoch());
 }
 
-inline void print_helper(const char* fmt) noexcept
-{
-  printk("%s", fmt);
-}
+inline void print_helper(const char* fmt) noexcept { printk("%s", fmt); }
 
-template<class T_FirstArg, class ...T_Args>
-inline void print_helper(const char* fmt, T_FirstArg&& first, T_Args&&... args) noexcept
-{
-  enum class state { normal, format, open_brace, close_brace, done };
+template <class T_FirstArg, class... T_Args>
+inline void print_helper(const char* fmt, T_FirstArg&& first, T_Args&&... args) noexcept {
+    enum class state { normal, format, open_brace, close_brace, done };
 
-  state s = state::normal;
-  size_t n = 0;
+    state s = state::normal;
+    size_t n = 0;
 
-  while (true) {
-    char c = fmt[n++];
+    while (true) {
+        char c = fmt[n++];
 
-    if (c == '\0') {
-      return;
+        if (c == '\0') {
+            return;
+        }
+
+        switch (s) {
+            case state::normal:
+                switch (c) {
+                    case '{':
+                        s = state::open_brace;
+                        break;
+                    case '}':
+                        s = state::close_brace;
+                        break;
+                    default:
+                        printk("%c", c);
+                        break;
+                }
+                break;
+
+            case state::open_brace:
+                switch (c) {
+                    case '{':
+                        s = state::normal;
+                        printk("{");
+                        break;
+
+                    case '}':
+                        s = state::done;
+                        break;
+
+                    default:
+                        s = state::format;
+                        break;
+                }
+                break;
+
+            case state::close_brace:
+                if (c == '}') {
+                    printk("}");
+                }
+                s = state::normal;
+                break;
+
+            case state::format:
+                switch (c) {
+                    case '}':
+                        s = state::done;
+                        break;
+                    default:
+                        break;
+                }
+                break;
+
+            case state::done:
+                break;
+        }
+
+        if (s == state::done) {
+            break;
+        }
     }
 
-    switch (s) {
-    case state::normal:
-      switch (c) {
-      case '{':
-        s = state::open_brace;
-        break;
-      case '}':
-        s = state::close_brace;
-        break;
-      default:
-        printk("%c", c);
-        break;
-      }
-      break;
-
-    case state::open_brace:
-      switch(c) {
-      case '{':
-        s = state::normal;
-        printk("{");
-        break;
-
-      case '}':
-        s = state::done;
-        break;
-
-      default:
-        s = state::format;
-        break;
-      }
-      break;
-
-    case state::close_brace:
-      if (c == '}') {
-        printk("}");
-      }
-      s = state::normal;
-      break;
-
-    case state::format:
-      switch (c) {
-      case '}':
-        s = state::done;
-        break;
-      default:
-        break;
-      }
-      break;
-
-    case state::done:
-      break;
-
-    }
-
-    if (s == state::done) {
-      break;
-    }
-  }
-
-  print_arg(std::forward<T_FirstArg>(first));
-  print_helper(&(fmt[n]), std::forward<T_Args>(args)...);
+    print_arg(std::forward<T_FirstArg>(first));
+    print_helper(&(fmt[n]), std::forward<T_Args>(args)...);
 }
 
-} // namespace internal
+}  // namespace internal
 
 ///
 /// @brief simple typesafe print function
@@ -153,12 +144,11 @@ inline void print_helper(const char* fmt, T_FirstArg&& first, T_Args&&... args) 
 /// @param fmt The format string using {} as place holder
 /// @param args The needed arguments to print
 ///
-template<class ...T_Args>
-inline void print(const char* fmt, T_Args&&... args) noexcept
-{
-  internal::print_helper(fmt, std::forward<T_Args>(args)...);
+template <class... T_Args>
+inline void print(const char* fmt, T_Args&&... args) noexcept {
+    internal::print_helper(fmt, std::forward<T_Args>(args)...);
 }
 
-} // namespace zpp
+}  // namespace zpp
 
-#endif // ZPP_INCLUDE_ZPP_FMT_HPP
+#endif  // ZPP_INCLUDE_ZPP_FMT_HPP

--- a/include/zpp/mem_slab.hpp
+++ b/include/zpp/mem_slab.hpp
@@ -102,7 +102,7 @@ public:
   void deallocate(void* vp) noexcept
   {
     if (vp != nullptr) {
-      k_mem_slab_free(native_handle(), &vp);
+      k_mem_slab_free(native_handle(), vp);
     }
   }
 

--- a/include/zpp/thread_data.hpp
+++ b/include/zpp/thread_data.hpp
@@ -8,7 +8,7 @@
 #define ZPP_INCLUDE_ZPP_THREAD_DATA_HPP
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #include <zephyr/sys/__assert.h>
 
 namespace zpp {

--- a/include/zpp/thread_stack.hpp
+++ b/include/zpp/thread_stack.hpp
@@ -8,7 +8,7 @@
 #define ZPP_INCLUDE_ZPP_THREAD_STACK_HPP
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/arch_interface.h>
 #include <zephyr/sys/__assert.h>
 
 namespace zpp {


### PR DESCRIPTION
These are the modifications required to compile with Zephyr 3.7 LTS.
- Update call to k_mem_slab_free to match Zephyr 3.5 API
- Update include files prefixes to new path
- Fix compiler warning around use of %f specifier for float type.